### PR TITLE
Aggregate split data

### DIFF
--- a/splitvar/cli.py
+++ b/splitvar/cli.py
@@ -29,9 +29,17 @@ def parse_args(args):
 
     # parser.add_argument('-v','--verbose', help='Verbose output', action='store_true')
     parser.add_argument('-f','--frequency', 
-                        help='Time frequency for output', 
+                        help='Time period to group for output', 
                         default='time.year', 
                         action='store')
+    parser.add_argument('--aggregate', 
+                        help='Apply mean in time, using pandas frequency notation e.g Y, 6M, 2Y', 
+                        default=None,
+                        action='store')
+    # parser.add_argument('--function', 
+    #                     help='Function to apply to aggregation', 
+    #                     default='mean',
+    #                     action='store')
     parser.add_argument('-v','--variables', 
                         help='Only extract specified variables', 
                         action='append')
@@ -136,10 +144,14 @@ def main(args):
             pass
         varlist = [var,] + getdependentvars(ds, var)
         dsbyvar = ds[varlist]
-        for dsbytime in groupbytime(dsbyvar, args.frequency):
+        if args.aggregate:
+            dsbyvar = dsbyvar.resample({'time': args.aggregate}).mean()
+        for dsbytime in groupbytime(dsbyvar, freq='time.year'):
             i += 1
+
             # TODO: Do something a bit cleverer to identify time variable
             timevar = dsbytime.time
+
             startdate=timevar.values[0].strftime(args.timeformat)
             enddate=timevar.values[-1].strftime(args.timeformat)
             fname = '{name}_{simulation}_{fromdate}_{todate}.nc'.format(

--- a/splitvar/cli.py
+++ b/splitvar/cli.py
@@ -145,7 +145,7 @@ def main(args):
         varlist = [var,] + getdependentvars(ds, var)
         dsbyvar = ds[varlist]
         if args.aggregate:
-            dsbyvar = dsbyvar.resample({'time': args.aggregate}).mean()
+            dsbyvar = dsbyvar.resample({'time': args.aggregate}, keep_attrs=True).mean(keep_attrs=True)
         for dsbytime in groupbytime(dsbyvar, freq='time.year'):
             i += 1
 


### PR DESCRIPTION
Can now apply an aggregation function (hardcoded as mean for the moment) to the data. Frequency for aggregation is specified independently of the split time.

Tried to use resample for both, but it didn't like to resample CFTime a second time, which is weird. So gone back to groupby for splitting the data up.